### PR TITLE
tubes are better with paper sticker labels on

### DIFF
--- a/FieldSampleCollectionSOP.md
+++ b/FieldSampleCollectionSOP.md
@@ -10,8 +10,8 @@ _Saccharomyces_ yeasts can live in a wide range of environments and we are espec
 **Essentials:**\
 camera\
 GPS\
-7ml tubes (e.g. for bark samples)\
-30ml tubes (e.g. for fig samples)\
+7ml tubes with with blank sticker-labels on (e.g. for bark samples)\
+30ml tubes with blank sticker-labels on (e.g. for fig samples)\
 disposable gloves\
 notebook\
 pen (bic)\


### PR DESCRIPTION
From DB: It's best to write with biro onto paper sticker labels on tubes. The tubes with stickers are usually the same price and our enrichment medium contains ethanol and so will easily wash away labels written onto plastic